### PR TITLE
Check for admin Authentication Middleware

### DIFF
--- a/WebService/Middleware/adminMiddleware.js
+++ b/WebService/Middleware/adminMiddleware.js
@@ -1,0 +1,17 @@
+const adminMiddleware = (req, res, next) => {
+    if (!req.user) {
+      console.error("No user found in request!");
+      return res.status(401).json({ message: "Unauthorized: No token provided!" });
+    }
+  
+    if (req.user.role !== "admin") {
+      console.error(`Access Denied! User ${req.user.email} is not admin.`);
+      return res.status(403).json({ message: "Forbidden: Admins only!" });
+    }
+  
+    console.log(`Admin access granted: ${req.user.email}`);
+    next();
+  };
+  
+  module.exports = adminMiddleware;
+  

--- a/WebService/Middleware/authMiddleware.js
+++ b/WebService/Middleware/authMiddleware.js
@@ -3,11 +3,9 @@ require('dotenv').config();
 
 const authMiddleware = (req, res, next) => {
     const token = req.header('Authorization');
-
     if (!token) {
         return res.status(401).json({ message: 'Access Denied. No token provided!' });
     }
-
     try {
         const tokenValue = token.startsWith("Bearer ") ? token.split(" ")[1] : token;
         const decoded = jwt.verify(tokenValue, process.env.JWT_SECRET);

--- a/WebService/Middleware/authMiddleware.js
+++ b/WebService/Middleware/authMiddleware.js
@@ -10,6 +10,7 @@ const authMiddleware = (req, res, next) => {
         const tokenValue = token.startsWith("Bearer ") ? token.split(" ")[1] : token;
         const decoded = jwt.verify(tokenValue, process.env.JWT_SECRET);
         req.user = decoded; 
+        console.log("✅ Decoded JWT:", decoded);
         next();
     } catch (error) {
         res.status(403).json({ message: 'Invalid or expired token!' });

--- a/WebService/app.js
+++ b/WebService/app.js
@@ -19,9 +19,10 @@ connection.connect(function (err) {
 
 const testroutes = require("./router/test.route.js");
 const activitiesroutes = require("./router/activities.route.js");
-
+const authroutes = require("./router/auth.route.js");
 app.use("/", testroutes);
 app.use("/activities", activitiesroutes);
+app.use("/auth", authroutes);
 
 app.use(function (req, res) {
   res.status(404).json({ message: "No such route exists" });

--- a/WebService/app.js
+++ b/WebService/app.js
@@ -11,12 +11,6 @@ app.use(express.urlencoded({ extended: true }));
 app.use(bodyParser.urlencoded({ extended: false }));
 app.use(bodyParser.json());
 
-const connection = require("./services/dbconn.js");
-connection.connect(function (err) {
-  if (err) throw err;
-  console.log(`Connected as ID ${connection.threadId}`);
-});
-
 const testroutes = require("./router/test.route.js");
 const activitiesroutes = require("./router/activities.route.js");
 const authroutes = require("./router/auth.route.js");

--- a/WebService/controller/auth.controller.js
+++ b/WebService/controller/auth.controller.js
@@ -30,7 +30,7 @@ const login = async (req, res) => {
     const token = jwt.sign(
       { id: user.id, email: user.email, role: user.role },
       process.env.JWT_SECRET,
-      { expiresIn: "1h" }
+      { expiresIn: "1d" }
     );
 
     console.log("Token Generated:", token);

--- a/WebService/controller/auth.controller.js
+++ b/WebService/controller/auth.controller.js
@@ -1,0 +1,44 @@
+const bcrypt = require("bcryptjs");
+const jwt = require("jsonwebtoken");
+const conn = require("../services/dbconn");
+require("dotenv").config();
+
+const login = async (req, res) => {
+  console.log("Login request received:", req.body);
+
+  const { email, password } = req.body;
+
+  try {
+    const [rows] = await conn.query("SELECT * FROM users WHERE email = ?", [
+      email,
+    ]);
+
+    if (rows.length === 0) {
+      console.log("User not found!");
+      return res.status(401).json({ error: "User not found!" });
+    }
+
+    const user = rows[0];
+    console.log("Found user:", user);
+
+    const isMatch = await bcrypt.compare(password, user.password);
+    if (!isMatch) {
+      console.log("Invalid password!");
+      return res.status(401).json({ error: "Invalid credentials!" });
+    }
+
+    const token = jwt.sign(
+      { id: user.id, email: user.email, role: user.role },
+      process.env.JWT_SECRET,
+      { expiresIn: "1h" }
+    );
+
+    console.log("Token Generated:", token);
+    res.json({ message: "Login successful!", token });
+  } catch (error) {
+    console.error("Server error:", error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+};
+
+module.exports = { login };

--- a/WebService/controller/test.controller.js
+++ b/WebService/controller/test.controller.js
@@ -16,7 +16,7 @@ const testJWT = (req, res) => {
 const testgenToken = (req, res) => {
     try {
         const user = { id: "12345", email: "test@example.com" };
-        const token = jwt.sign(user, process.env.JWT_SECRET, { expiresIn: process.env.JWT_EXPIRES_IN });
+        const token = jwt.sign(user, process.env.JWT_SECRET, { expiresIn: "1d" });
 
         res.json({ token });
     } catch (error) {

--- a/WebService/router/auth.route.js
+++ b/WebService/router/auth.route.js
@@ -1,6 +1,7 @@
 const express = require("express");
 const route = express.Router();
+const { login } = require("../controller/auth.controller.js");
 
-route.get("/login");
+route.post("/login", login);
 
 module.exports = route;

--- a/WebService/router/auth.route.js
+++ b/WebService/router/auth.route.js
@@ -2,3 +2,5 @@ const express = require("express");
 const route = express.Router();
 
 route.get("/login");
+
+module.exports = route;

--- a/WebService/router/auth.route.js
+++ b/WebService/router/auth.route.js
@@ -1,0 +1,4 @@
+const express = require("express");
+const route = express.Router();
+
+route.get("/login");

--- a/WebService/router/test.route.js
+++ b/WebService/router/test.route.js
@@ -1,9 +1,14 @@
 const express = require("express");
-const { testSys, testJWT , testgenToken} = require("../controller/test.controller.js");
+const {
+  testSys,
+  testJWT,
+  testgenToken,
+} = require("../controller/test.controller.js");
 const route = express.Router();
 const authMiddleware = require("../Middleware/authMiddleware.js");
-
+const adminMiddleware = require("../Middleware/adminMiddleware.js");
 route.get("/test", testSys);
 route.get("/testAuth", authMiddleware, testJWT);
-route.get('/testgenToken', testgenToken);
+route.get("/testgenToken", testgenToken);
+route.post("/testAdmin", authMiddleware, adminMiddleware);
 module.exports = route;

--- a/WebService/services/dbconn.js
+++ b/WebService/services/dbconn.js
@@ -1,11 +1,14 @@
-const mysql = require("mysql2");
+const mysql = require("mysql2/promise");
 
 // XAMPP
-const connection = mysql.createConnection({
+const pool = mysql.createPool({
     host: "mysql",
     user: "root",
     password: "password",
-    database: "my_database"
+    database: "my_database",
+    waitForConnections: true,
+    connectionLimit: 10,
+    queueLimit: 0
 })
 
-module.exports = connection;
+module.exports = pool;

--- a/WebService/services/fetch.services.js
+++ b/WebService/services/fetch.services.js
@@ -1,10 +1,5 @@
 const connection = require("./dbconn");
 
-connection.connect(function (err) {
-  if (err) throw err;
-  console.log("Connected to mySQL");
-});
-
 const FetchService = {
   getAllData: async (tableName1, tableName2) => {
     return new Promise((resolve, reject) => {


### PR DESCRIPTION
# Database Connection Update: `createPool` instead of `createConnection`

I updated `dbconn.js` to use `createPool` instead of `createConnection`. This allows automatic connection management, better error handling, and the ability to handle multiple requests concurrently.

## Test Environment

### `.env` file
```env
JWT_SECRET = e129f3d1f7b65c5a8e3a97c18f8c4478a5b40d51c6f6bb9c3a18328f29f2df67
```

### Users Table
I created the `users` table as follows, but I'm not sure if this is the exact structure needed.
```sql
CREATE TABLE users (
    id INT AUTO_INCREMENT PRIMARY KEY,
    email VARCHAR(255) NOT NULL UNIQUE,
    password VARCHAR(255) NOT NULL,
    role ENUM('admin', 'user') NOT NULL DEFAULT 'user',
    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
);
```

### Sample Data
```sql
INSERT INTO users (email, password, role)
VALUES
('admin@gmail.com', 'HsZ1VB575pqgV6VtgHW48OShHl0fqrnbyYnrTfw7PNmUI7JTKBU0q', 'admin'),
('user@gmail.com', '$2a$10$qVFkHb3a5R1jUKWSOcgPKeNrgahTvUa2TBL8d/cbO6h6l2QbIAVUi', 'user');
```

## Changes Made
- **Middleware** (`/Middleware/adminMiddleware.js`)
  - Implemented admin checker middleware.

- **Authentication Controller** (`auth.controller.js`)
  - I only use it to generate a token and check it against the database.
  - Endpoint: `POST /auth/login`

- **New Admin Test Endpoint:** `POST /testAdmin`
  - Checks if a token exists.  
  - Validates the user role.

## Testing

### 1. Login to Get a Token
Use the `POST` method on `/auth/login` with the following JSON body:

#### Admin Login:
```json
{
  "email": "admin@gmail.com",
  "password": "adminpassword"
}
```

#### User Login:
```json
{
  "email": "user@gmail.com",
  "password": "password"
}
```

This will return a token.

### 2. Test Admin Access
Use the `POST` method on `/testAdmin`.  
In the **Headers**, use the key `Authorization` and provide the token obtained from login.

**No request body is required.**  
All results will be logged to the console, which you can view in **Docker Desktop logs**.
---
